### PR TITLE
feat: Write stderr and stdout from Docker executor

### DIFF
--- a/examples/docker.rs
+++ b/examples/docker.rs
@@ -16,6 +16,8 @@ async fn main() {
         .extend_executors(vec![Execution::builder()
             .image("ubuntu")
             .args(&[String::from("echo"), String::from("'hello, world!'")])
+            .stdout("stdout.txt")
+            .stderr("stderr.txt")
             .try_build()
             .unwrap()])
         .unwrap()

--- a/examples/docker.rs
+++ b/examples/docker.rs
@@ -24,5 +24,6 @@ async fn main() {
         .try_build()
         .unwrap();
 
-    docker.submit(task).await;
+    let result = docker.submit(task).await.unwrap();
+    println!("Exit code: {:?}", &result)
 }

--- a/src/engine/service/runner/backend/docker.rs
+++ b/src/engine/service/runner/backend/docker.rs
@@ -2,10 +2,17 @@
 
 use crate::engine::Task;
 
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
 use bollard::container::Config;
 use bollard::container::CreateContainerOptions;
+use bollard::container::LogsOptions;
+use bollard::container::LogOutput;
 use bollard::container::StartContainerOptions;
 use bollard::errors::Error;
+use futures::stream::StreamExt;
 use random_word::Lang;
 
 /// The default runner service name.
@@ -28,6 +35,12 @@ impl Docker {
     /// Submits a task.
     pub async fn submit(&mut self, task: Task) {
         for executor in task.executions() {
+            // Create stdout/stderr files if required
+            let stdout_path = executor.stdout().map(|s| Path::new(s));
+            let mut stdout_file = stdout_path.map(|path| File::create(path).expect("Failed to create stdout file"));
+            let stderr_path = executor.stderr().map(|s| Path::new(s));
+            let mut stderr_file = stderr_path.map(|path| File::create(path).expect("Failed to create stderr file"));
+
             let name = (1..=3)
                 .map(|_| random_word::r#gen(Lang::En))
                 .collect::<Vec<_>>()
@@ -48,10 +61,35 @@ impl Docker {
 
             println!("{job:?}");
 
+            // Capture logs
+            let options = LogsOptions::<String>{
+                stdout: executor.stdout().is_some(),
+                stderr: executor.stderr().is_some(),
+                ..Default::default()
+            };
+            let mut logs_stream = self.docker.logs(&name, Some(options));
+            
             self.docker
                 .start_container(&name, None::<StartContainerOptions<String>>)
                 .await
                 .unwrap();
+            
+            while let Some(log_result) = logs_stream.next().await {
+                match log_result {
+                    Ok(LogOutput::StdOut {message}) => { 
+                        if let Some(file) = &mut stdout_file {
+                            file.write_all(&message).expect("Failed to write to stdout file");
+                        }
+                    }
+                    Ok(LogOutput::StdErr {message}) => {
+                        if let Some(file) = &mut stderr_file {
+                            file.write_all(&message).expect("Failed to write to stdout file");
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => eprintln!("Error reading log: {:?}", e),   
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
If stdout or stderr are defined in an Execution, the docker backend will write to them.

Currently the example writes them to the main directory.

Made an attempt to return an error code and cleanup the container. Currently it seems an error raised prevents the container from being shut down- I think my handling of `wait_result` isn't quite right. It seems there may be a race condition of sorts since the stdout is sometimes empty...