### PR TITLE
Process logs before waiting container

### DIFF
--- a/src/engine/service/runner/backend/docker.rs
+++ b/src/engine/service/runner/backend/docker.rs
@@ -66,18 +66,21 @@ impl Runner {
 
                 // Process logs until they stop when container stops
                 let (stdout, stderr) = logs
-                    .try_fold((String::new(), String::new()), |(mut stdout, mut stderr), log| async move {
-                        match log {
-                            LogOutput::StdOut { message } => {
-                                stdout.push_str(&String::from_utf8_lossy(&message));
+                    .try_fold(
+                        (String::new(), String::new()),
+                        |(mut stdout, mut stderr), log| async move {
+                            match log {
+                                LogOutput::StdOut { message } => {
+                                    stdout.push_str(&String::from_utf8_lossy(&message));
+                                }
+                                LogOutput::StdErr { message } => {
+                                    stderr.push_str(&String::from_utf8_lossy(&message));
+                                }
+                                _ => {}
                             }
-                            LogOutput::StdErr { message } => {
-                                stderr.push_str(&String::from_utf8_lossy(&message));
-                            }
-                            _ => {}
-                        }
-                        Ok((stdout, stderr))
-                    })
+                            Ok((stdout, stderr))
+                        },
+                    )
                     .await
                     .unwrap_or_else(|e| {
                         eprintln!("Error collecting logs: {:?}", e);
@@ -85,7 +88,9 @@ impl Runner {
                     });
 
                 // Process container stop
-                let status = wait.next().await
+                let status = wait
+                    .next()
+                    .await
                     .transpose()
                     .unwrap_or_else(|e| {
                         eprintln!("Error waiting for container: {:?}", e);

--- a/src/engine/service/runner/backend/docker.rs
+++ b/src/engine/service/runner/backend/docker.rs
@@ -67,7 +67,7 @@ impl Runner {
                 // Process logs until they stop when container stops
                 let (stdout, stderr) = logs
                     .try_fold(
-                        (String::new(), String::new()),
+                        (String::with_capacity(1 << 8), String::with_capacity(1 << 8)),
                         |(mut stdout, mut stderr), log| async move {
                             match log {
                                 LogOutput::StdOut { message } => {


### PR DESCRIPTION
We may process the `wait_container` before all logs are collected, causing us to lose some.

Instead we can process the logs until that stream ends (which happens when the container ends) then process the `wait_container`.

Before:

```
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
```

After:

```
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
Reply: Reply { executions: NonEmpty { head: ExecutionResult { status: 0, stdout: "'hello, world!'\n", stderr: "" }, tail: [] } }
```