### PR TITLE
Docker Resource Input Parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target
 Cargo.lock
+.idea/
+
+stderr.txt
+stdout.txt

--- a/src/engine/task/resources.rs
+++ b/src/engine/task/resources.rs
@@ -2,6 +2,9 @@
 
 mod builder;
 
+use std::collections::HashMap;
+
+use bollard::secret::HostConfig;
 pub use builder::Builder;
 
 use nonempty::NonEmpty;
@@ -49,5 +52,26 @@ impl Resources {
     /// The set of requested zones.
     pub fn zones(&self) -> Option<&NonEmpty<String>> {
         self.zones.as_ref()
+    }
+}
+
+impl From<&Resources> for HostConfig {
+    fn from(resources: &Resources) -> Self {
+        let mut host_config = HostConfig::default();
+        if let Some(ram_gb) = resources.ram_gb() {
+            host_config.memory = Some((ram_gb * 1024. * 1024. * 1024.) as i64);
+        }
+
+        if let Some(cpu_cores) = resources.cpu_cores() {
+            host_config.cpu_count = Some(cpu_cores as i64);
+        }
+
+        if let Some(disk_gb) = resources.disk_gb() {
+            let mut storage_opt: HashMap<String, String> = HashMap::new();
+            storage_opt.insert("size".to_string(), disk_gb.to_string());
+            host_config.storage_opt = Some(storage_opt);
+        }
+
+        host_config
     }
 }

--- a/src/engine/task/resources/builder.rs
+++ b/src/engine/task/resources/builder.rs
@@ -1,11 +1,12 @@
 //! Builders for a [`Resources`].
 
 use nonempty::NonEmpty;
+use tracing::warn;
 
 use crate::engine::task::resources::Resources;
 
 /// A builder for a [`Resources`].
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Builder {
     /// The number of CPU cores requested.
     cpu_cores: Option<u64>,
@@ -64,8 +65,12 @@ impl Builder {
     ///
     /// This will silently overwrite any previously requested amount of disk
     /// space provided to the builder.
-    pub fn disk_gb(mut self, value: impl Into<f64>) -> Self {
-        self.disk_gb = Some(value.into());
+    pub fn disk_gb(self, _: impl Into<f64>) -> Self {
+        warn!(
+            "setting disk space does not work on containers unless \
+            XFS is used on the host machine"
+        );
+
         self
     }
 


### PR DESCRIPTION
• ✨ Adds impl From<&Resources> for HostConfig { } to resources.rs
• ✨ Adds fn builder() -> Builder { } to Resources impl in resources.rs
• ✨ Adjusts fn disk_gb() in resources/builder.rs to warn about XFS disk space setting limitations
• ✨ Adds HostConfig object to service/runner/backend/docker.rs
• ✨ Adds .resources(Resources::builder()) in task Builder in examples/docker.rs
• 🔥 Adds stderr.txt and stdout.txt to .gitignore