### PR TITLE
Support use of volumes in docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tes-client",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ random_word = { version = "0.4.3", features = ["en"] }
 reqwest = "0.12.7"
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.128"
+tempfile = "3.12.0"
 tes-client = { path = "./tes-client", version = "0.1.0" }
 tokio = { version = "1.40.0", features = ["full", "time"] }
 toml = "0.8.19"

--- a/examples/docker.rs
+++ b/examples/docker.rs
@@ -30,6 +30,8 @@ async fn main() {
             .try_build()
             .unwrap()])
         .unwrap()
+        .extend_volumes(vec!["/volA".to_string(), "/volB".to_string()])
+        .unwrap()
         .try_build()
         .unwrap();
 

--- a/src/engine/service/runner/backend/docker/tmp_mount.rs
+++ b/src/engine/service/runner/backend/docker/tmp_mount.rs
@@ -1,0 +1,38 @@
+//! Create local temporary folders to mount in docker containers
+
+use std::str::FromStr;
+
+use bollard::models::Mount;
+use bollard::models::MountTypeEnum;
+use tempfile::TempDir;
+
+/// Mount a local TempDir to a mount shared amongst the executors in a tast
+pub struct TmpMount {
+    /// local temp directory mounted as a volume
+    local_path: TempDir,
+
+    /// path used to mount in the container
+    container_path: String,
+}
+
+impl FromStr for TmpMount {
+    type Err = std::io::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(TmpMount {
+            local_path: TempDir::new()?,
+            container_path: s.to_string(),
+        })
+    }
+}
+
+impl From<&TmpMount> for Mount {
+    fn from(val: &TmpMount) -> Self {
+        Mount {
+            target: Some(val.container_path.clone()),
+            source: Some(val.local_path.path().to_str().unwrap().to_string()),
+            typ: Some(MountTypeEnum::BIND),
+            ..Default::default()
+        }
+    }
+}

--- a/src/engine/task.rs
+++ b/src/engine/task.rs
@@ -35,6 +35,9 @@ pub struct Task {
 
     /// The list of [`Execution`]s.
     executions: NonEmpty<Execution>,
+
+    /// The list of volumes shared across executions in the task
+    volumes: Option<NonEmpty<String>>,
 }
 
 impl Task {
@@ -71,5 +74,10 @@ impl Task {
     /// Gets the executions for this task.
     pub fn executions(&self) -> impl Iterator<Item = &Execution> {
         self.executions.iter()
+    }
+
+    /// Gets the volumes for this task.
+    pub fn volumes(&self) -> Option<impl Iterator<Item = &String>> {
+        self.volumes.as_ref().map(|volumes| volumes.iter())
     }
 }


### PR DESCRIPTION
- Tasks now have `Option<NonEmpty<String>>` volumes, e.g. `/VolA` which persist across the executions
- These are mapped to local temp directories which are cleaned up when all executions are finished
- A special working directory mount (`/workdir`) is used within each execution and cleaned up when the execution finishes. Eventually inputs should be copied or symlinked there and outputs can be copied/sent out of there after execution is complete, even after the container shuts down.